### PR TITLE
Add Homebrew installation method to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A command-line interface for interacting with Honeybadger's Reporting API and Da
 
 ## Installation
 
+### Homebrew
+
+```bash
+brew install honeybadger-io/tap/honeybadger
+```
+
+### Go
+
 ```bash
 go install github.com/honeybadger-io/cli/cmd/hb@latest
 ```

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ go install github.com/honeybadger-io/cli/cmd/hb@latest
 
 Note: The install path includes `/cmd/hb` so Go installs the `hb` binary name.
 
+### Download from GitHub
+
+Pre-built binaries for Linux, macOS, and Windows are available on the [GitHub releases page](https://github.com/honeybadger-io/cli/releases).
+
 ## Configuration
 
 The CLI can be configured using either command-line flags, environment variables, or a configuration file.


### PR DESCRIPTION
## Summary
Added Homebrew as the primary installation option in the README, making it more discoverable for users. The Homebrew tap is already configured in GoReleaser for automatic formula updates on releases.

## Test plan
- [x] README renders correctly on GitHub
- [x] Homebrew installation command is accurate