### PR TITLE
Add support for default project ID via config and environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Example configuration file:
 ```yaml
 api_key: your-project-api-key-here      # For Reporting API (deploy, agent commands)
 auth_token: your-personal-auth-token    # For Data API (projects, faults, insights commands)
+project_id: 12345                       # Optional, default project ID for Data API commands
 endpoint: https://api.honeybadger.io    # Optional, use https://eu-api.honeybadger.io for EU region
 ```
 
@@ -46,6 +47,7 @@ You can set configuration using environment variables prefixed with `HONEYBADGER
 ```bash
 export HONEYBADGER_API_KEY=your-project-api-key-here       # For Reporting API (deploy, agent)
 export HONEYBADGER_AUTH_TOKEN=your-personal-auth-token     # For Data API (projects, faults, insights)
+export HONEYBADGER_PROJECT_ID=12345                        # Optional, default project ID for Data API commands
 export HONEYBADGER_ENDPOINT=https://eu-api.honeybadger.io  # Optional, for EU region
 ```
 

--- a/cmd/checkins.go
+++ b/cmd/checkins.go
@@ -37,7 +37,9 @@ var checkinsListCmd = &cobra.Command{
 			checkinsProjectID = viper.GetInt("project_id")
 		}
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -107,7 +109,9 @@ var checkinsGetCmd = &cobra.Command{
 			checkinsProjectID = viper.GetInt("project_id")
 		}
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")
@@ -204,7 +208,9 @@ Example JSON payload for cron schedule:
 			checkinsProjectID = viper.GetInt("project_id")
 		}
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if checkinCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -279,7 +285,9 @@ Example JSON payload:
 			checkinsProjectID = viper.GetInt("project_id")
 		}
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")
@@ -356,7 +364,9 @@ var checkinsDeleteCmd = &cobra.Command{
 			checkinsProjectID = viper.GetInt("project_id")
 		}
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")

--- a/cmd/checkins.go
+++ b/cmd/checkins.go
@@ -33,13 +33,8 @@ var checkinsListCmd = &cobra.Command{
 	Short: "List check-ins for a project",
 	Long:  `List all check-ins configured for a specific project.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if checkinsProjectID == 0 {
-			checkinsProjectID = viper.GetInt("project_id")
-		}
-		if checkinsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&checkinsProjectID); err != nil {
+			return err
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -105,13 +100,8 @@ var checkinsGetCmd = &cobra.Command{
 	Short: "Get a check-in by ID",
 	Long:  `Get detailed information about a specific check-in.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if checkinsProjectID == 0 {
-			checkinsProjectID = viper.GetInt("project_id")
-		}
-		if checkinsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&checkinsProjectID); err != nil {
+			return err
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")
@@ -204,13 +194,8 @@ Example JSON payload for cron schedule:
   }
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if checkinsProjectID == 0 {
-			checkinsProjectID = viper.GetInt("project_id")
-		}
-		if checkinsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&checkinsProjectID); err != nil {
+			return err
 		}
 		if checkinCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -281,13 +266,8 @@ Example JSON payload:
   }
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if checkinsProjectID == 0 {
-			checkinsProjectID = viper.GetInt("project_id")
-		}
-		if checkinsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&checkinsProjectID); err != nil {
+			return err
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")
@@ -360,13 +340,8 @@ var checkinsDeleteCmd = &cobra.Command{
 	Short: "Delete a check-in",
 	Long:  `Delete a check-in by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if checkinsProjectID == 0 {
-			checkinsProjectID = viper.GetInt("project_id")
-		}
-		if checkinsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&checkinsProjectID); err != nil {
+			return err
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")

--- a/cmd/checkins.go
+++ b/cmd/checkins.go
@@ -34,7 +34,10 @@ var checkinsListCmd = &cobra.Command{
 	Long:  `List all check-ins configured for a specific project.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			checkinsProjectID = viper.GetInt("project_id")
+		}
+		if checkinsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -101,7 +104,10 @@ var checkinsGetCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific check-in.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			checkinsProjectID = viper.GetInt("project_id")
+		}
+		if checkinsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")
@@ -195,7 +201,10 @@ Example JSON payload for cron schedule:
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			checkinsProjectID = viper.GetInt("project_id")
+		}
+		if checkinsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if checkinCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -267,7 +276,10 @@ Example JSON payload:
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			checkinsProjectID = viper.GetInt("project_id")
+		}
+		if checkinsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")
@@ -341,7 +353,10 @@ var checkinsDeleteCmd = &cobra.Command{
 	Long:  `Delete a check-in by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if checkinsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			checkinsProjectID = viper.GetInt("project_id")
+		}
+		if checkinsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if checkinID == "" {
 			return fmt.Errorf("check-in ID is required. Set it using --id flag")

--- a/cmd/checkins_test.go
+++ b/cmd/checkins_test.go
@@ -175,6 +175,31 @@ func TestCheckinsGetCommand(t *testing.T) {
 	}
 }
 
+func TestCheckinsViperProjectIDFallback(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"results": [{"id": "abc123", "name": "Daily Backup", "slug": "daily-backup", "schedule_type": "simple", "report_period": "1 day"}],
+				"links": {"self": "/v2/projects/123/check_ins"}
+			}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+	viper.Set("project_id", 123)
+
+	checkinsProjectID = 0
+	checkinsOutputFormat = "table"
+
+	err := checkinsListCmd.RunE(checkinsListCmd, []string{})
+	assert.NoError(t, err)
+}
+
 func TestCheckinsOutputFormat(t *testing.T) {
 	mockResponse := `{
 		"results": [{"id": "abc123", "name": "Daily Backup", "slug": "daily-backup", "schedule_type": "simple", "report_period": "1 day"}],

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -34,13 +34,8 @@ var commentsListCmd = &cobra.Command{
 	Short: "List comments for a fault",
 	Long:  `List all comments on a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if commentsProjectID == 0 {
-			commentsProjectID = viper.GetInt("project_id")
-		}
-		if commentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&commentsProjectID); err != nil {
+			return err
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -106,13 +101,8 @@ var commentsGetCmd = &cobra.Command{
 	Short: "Get a comment by ID",
 	Long:  `Get detailed information about a specific comment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if commentsProjectID == 0 {
-			commentsProjectID = viper.GetInt("project_id")
-		}
-		if commentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&commentsProjectID); err != nil {
+			return err
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -170,13 +160,8 @@ var commentsCreateCmd = &cobra.Command{
 	Short: "Create a new comment",
 	Long:  `Create a new comment on a fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if commentsProjectID == 0 {
-			commentsProjectID = viper.GetInt("project_id")
-		}
-		if commentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&commentsProjectID); err != nil {
+			return err
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -227,13 +212,8 @@ var commentsUpdateCmd = &cobra.Command{
 	Short: "Update an existing comment",
 	Long:  `Update the body of an existing comment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if commentsProjectID == 0 {
-			commentsProjectID = viper.GetInt("project_id")
-		}
-		if commentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&commentsProjectID); err != nil {
+			return err
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -297,13 +277,8 @@ var commentsDeleteCmd = &cobra.Command{
 	Short: "Delete a comment",
 	Long:  `Delete a comment by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if commentsProjectID == 0 {
-			commentsProjectID = viper.GetInt("project_id")
-		}
-		if commentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&commentsProjectID); err != nil {
+			return err
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -38,7 +38,9 @@ var commentsListCmd = &cobra.Command{
 			commentsProjectID = viper.GetInt("project_id")
 		}
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -108,7 +110,9 @@ var commentsGetCmd = &cobra.Command{
 			commentsProjectID = viper.GetInt("project_id")
 		}
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -170,7 +174,9 @@ var commentsCreateCmd = &cobra.Command{
 			commentsProjectID = viper.GetInt("project_id")
 		}
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -225,7 +231,9 @@ var commentsUpdateCmd = &cobra.Command{
 			commentsProjectID = viper.GetInt("project_id")
 		}
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -293,7 +301,9 @@ var commentsDeleteCmd = &cobra.Command{
 			commentsProjectID = viper.GetInt("project_id")
 		}
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")

--- a/cmd/comments.go
+++ b/cmd/comments.go
@@ -35,7 +35,10 @@ var commentsListCmd = &cobra.Command{
 	Long:  `List all comments on a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			commentsProjectID = viper.GetInt("project_id")
+		}
+		if commentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -102,7 +105,10 @@ var commentsGetCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific comment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			commentsProjectID = viper.GetInt("project_id")
+		}
+		if commentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -161,7 +167,10 @@ var commentsCreateCmd = &cobra.Command{
 	Long:  `Create a new comment on a fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			commentsProjectID = viper.GetInt("project_id")
+		}
+		if commentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -213,7 +222,10 @@ var commentsUpdateCmd = &cobra.Command{
 	Long:  `Update the body of an existing comment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			commentsProjectID = viper.GetInt("project_id")
+		}
+		if commentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")
@@ -278,7 +290,10 @@ var commentsDeleteCmd = &cobra.Command{
 	Long:  `Delete a comment by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if commentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			commentsProjectID = viper.GetInt("project_id")
+		}
+		if commentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if commentsFaultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --fault-id flag")

--- a/cmd/dataapi_test.go
+++ b/cmd/dataapi_test.go
@@ -247,6 +247,76 @@ func TestEnvironmentsListCommand(t *testing.T) {
 	}
 }
 
+// TestCommentsViperProjectIDFallback tests that the comments command uses viper project_id fallback
+func TestCommentsViperProjectIDFallback(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results": [], "links": {"self": "/v2/projects/123/faults/456/comments"}}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+	viper.Set("project_id", 123)
+
+	commentsProjectID = 0
+	commentsFaultID = 456
+	commentsOutputFormat = "table"
+
+	err := commentsListCmd.RunE(commentsListCmd, []string{})
+	assert.NoError(t, err)
+}
+
+// TestDeploymentsViperProjectIDFallback tests that the deployments command uses viper project_id fallback
+func TestDeploymentsViperProjectIDFallback(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results": [], "links": {"self": "/v2/projects/123/deploys"}}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+	viper.Set("project_id", 123)
+
+	deploymentsProjectID = 0
+	deploymentsOutputFormat = "table"
+
+	err := deploymentsListCmd.RunE(deploymentsListCmd, []string{})
+	assert.NoError(t, err)
+}
+
+// TestEnvironmentsViperProjectIDFallback tests that the environments command uses viper project_id fallback
+func TestEnvironmentsViperProjectIDFallback(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results": [], "links": {"self": "/v2/projects/123/environments"}}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+	viper.Set("project_id", 123)
+
+	environmentsProjectID = 0
+	environmentsOutputFormat = "table"
+
+	err := environmentsListCmd.RunE(environmentsListCmd, []string{})
+	assert.NoError(t, err)
+}
+
 // TestStatuspagesListCommand tests the statuspages list command validation
 func TestStatuspagesListCommand(t *testing.T) {
 	tests := []struct {

--- a/cmd/dataapi_test.go
+++ b/cmd/dataapi_test.go
@@ -253,7 +253,11 @@ func TestCommentsViperProjectIDFallback(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"results": [], "links": {"self": "/v2/projects/123/faults/456/comments"}}`))
+			_, _ = w.Write(
+				[]byte(
+					`{"results": [], "links": {"self": "/v2/projects/123/faults/456/comments"}}`,
+				),
+			)
 		}),
 	)
 	defer server.Close()
@@ -300,7 +304,9 @@ func TestEnvironmentsViperProjectIDFallback(t *testing.T) {
 		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"results": [], "links": {"self": "/v2/projects/123/environments"}}`))
+			_, _ = w.Write(
+				[]byte(`{"results": [], "links": {"self": "/v2/projects/123/environments"}}`),
+			)
 		}),
 	)
 	defer server.Close()

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -41,7 +41,9 @@ var deploymentsListCmd = &cobra.Command{
 			deploymentsProjectID = viper.GetInt("project_id")
 		}
 		if deploymentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -111,7 +113,9 @@ var deploymentsGetCmd = &cobra.Command{
 			deploymentsProjectID = viper.GetInt("project_id")
 		}
 		if deploymentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if deploymentID == 0 {
 			return fmt.Errorf("deployment ID is required. Set it using --id flag")
@@ -168,7 +172,9 @@ var deploymentsDeleteCmd = &cobra.Command{
 			deploymentsProjectID = viper.GetInt("project_id")
 		}
 		if deploymentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if deploymentID == 0 {
 			return fmt.Errorf("deployment ID is required. Set it using --id flag")

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -38,7 +38,10 @@ var deploymentsListCmd = &cobra.Command{
 	Long:  `List all deployments for a specific project with optional filtering.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if deploymentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			deploymentsProjectID = viper.GetInt("project_id")
+		}
+		if deploymentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -105,7 +108,10 @@ var deploymentsGetCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific deployment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if deploymentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			deploymentsProjectID = viper.GetInt("project_id")
+		}
+		if deploymentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if deploymentID == 0 {
 			return fmt.Errorf("deployment ID is required. Set it using --id flag")
@@ -159,7 +165,10 @@ var deploymentsDeleteCmd = &cobra.Command{
 	Long:  `Delete a deployment record by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if deploymentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			deploymentsProjectID = viper.GetInt("project_id")
+		}
+		if deploymentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if deploymentID == 0 {
 			return fmt.Errorf("deployment ID is required. Set it using --id flag")

--- a/cmd/deployments.go
+++ b/cmd/deployments.go
@@ -37,13 +37,8 @@ var deploymentsListCmd = &cobra.Command{
 	Short: "List deployments for a project",
 	Long:  `List all deployments for a specific project with optional filtering.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if deploymentsProjectID == 0 {
-			deploymentsProjectID = viper.GetInt("project_id")
-		}
-		if deploymentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&deploymentsProjectID); err != nil {
+			return err
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -109,13 +104,8 @@ var deploymentsGetCmd = &cobra.Command{
 	Short: "Get a deployment by ID",
 	Long:  `Get detailed information about a specific deployment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if deploymentsProjectID == 0 {
-			deploymentsProjectID = viper.GetInt("project_id")
-		}
-		if deploymentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&deploymentsProjectID); err != nil {
+			return err
 		}
 		if deploymentID == 0 {
 			return fmt.Errorf("deployment ID is required. Set it using --id flag")
@@ -168,13 +158,8 @@ var deploymentsDeleteCmd = &cobra.Command{
 	Short: "Delete a deployment",
 	Long:  `Delete a deployment record by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if deploymentsProjectID == 0 {
-			deploymentsProjectID = viper.GetInt("project_id")
-		}
-		if deploymentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&deploymentsProjectID); err != nil {
+			return err
 		}
 		if deploymentID == 0 {
 			return fmt.Errorf("deployment ID is required. Set it using --id flag")

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -33,13 +33,8 @@ var environmentsListCmd = &cobra.Command{
 	Short: "List environments for a project",
 	Long:  `List all environments configured for a specific project.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if environmentsProjectID == 0 {
-			environmentsProjectID = viper.GetInt("project_id")
-		}
-		if environmentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&environmentsProjectID); err != nil {
+			return err
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -96,13 +91,8 @@ var environmentsGetCmd = &cobra.Command{
 	Short: "Get an environment by ID",
 	Long:  `Get detailed information about a specific environment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if environmentsProjectID == 0 {
-			environmentsProjectID = viper.GetInt("project_id")
-		}
-		if environmentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&environmentsProjectID); err != nil {
+			return err
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")
@@ -164,13 +154,8 @@ Example JSON payload:
   }
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if environmentsProjectID == 0 {
-			environmentsProjectID = viper.GetInt("project_id")
-		}
-		if environmentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&environmentsProjectID); err != nil {
+			return err
 		}
 		if environmentCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -244,13 +229,8 @@ Example JSON payload:
   }
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if environmentsProjectID == 0 {
-			environmentsProjectID = viper.GetInt("project_id")
-		}
-		if environmentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&environmentsProjectID); err != nil {
+			return err
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")
@@ -306,13 +286,8 @@ var environmentsDeleteCmd = &cobra.Command{
 	Short: "Delete an environment",
 	Long:  `Delete an environment by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if environmentsProjectID == 0 {
-			environmentsProjectID = viper.GetInt("project_id")
-		}
-		if environmentsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&environmentsProjectID); err != nil {
+			return err
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -34,7 +34,10 @@ var environmentsListCmd = &cobra.Command{
 	Long:  `List all environments configured for a specific project.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			environmentsProjectID = viper.GetInt("project_id")
+		}
+		if environmentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -92,7 +95,10 @@ var environmentsGetCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific environment.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			environmentsProjectID = viper.GetInt("project_id")
+		}
+		if environmentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")
@@ -155,7 +161,10 @@ Example JSON payload:
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			environmentsProjectID = viper.GetInt("project_id")
+		}
+		if environmentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if environmentCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -230,7 +239,10 @@ Example JSON payload:
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			environmentsProjectID = viper.GetInt("project_id")
+		}
+		if environmentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")
@@ -287,7 +299,10 @@ var environmentsDeleteCmd = &cobra.Command{
 	Long:  `Delete an environment by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			environmentsProjectID = viper.GetInt("project_id")
+		}
+		if environmentsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -37,7 +37,9 @@ var environmentsListCmd = &cobra.Command{
 			environmentsProjectID = viper.GetInt("project_id")
 		}
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -98,7 +100,9 @@ var environmentsGetCmd = &cobra.Command{
 			environmentsProjectID = viper.GetInt("project_id")
 		}
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")
@@ -164,7 +168,9 @@ Example JSON payload:
 			environmentsProjectID = viper.GetInt("project_id")
 		}
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if environmentCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -242,7 +248,9 @@ Example JSON payload:
 			environmentsProjectID = viper.GetInt("project_id")
 		}
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")
@@ -302,7 +310,9 @@ var environmentsDeleteCmd = &cobra.Command{
 			environmentsProjectID = viper.GetInt("project_id")
 		}
 		if environmentsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if environmentID == 0 {
 			return fmt.Errorf("environment ID is required. Set it using --id flag")

--- a/cmd/faults.go
+++ b/cmd/faults.go
@@ -37,7 +37,10 @@ var faultsListCmd = &cobra.Command{
 	Long:  `List all faults for a specific project with optional filtering.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			faultsProjectID = viper.GetInt("project_id")
+		}
+		if faultsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -118,7 +121,10 @@ var faultsGetCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			faultsProjectID = viper.GetInt("project_id")
+		}
+		if faultsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")
@@ -200,7 +206,10 @@ var faultsNoticesCmd = &cobra.Command{
 	Long:  `List individual error occurrences (notices) for a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			faultsProjectID = viper.GetInt("project_id")
+		}
+		if faultsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")
@@ -270,7 +279,10 @@ var faultsCountsCmd = &cobra.Command{
 	Long:  `Get summary counts of faults grouped by environment and status.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			faultsProjectID = viper.GetInt("project_id")
+		}
+		if faultsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -329,7 +341,10 @@ var faultsAffectedUsersCmd = &cobra.Command{
 	Long:  `List all users who have been affected by a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			faultsProjectID = viper.GetInt("project_id")
+		}
+		if faultsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")

--- a/cmd/faults.go
+++ b/cmd/faults.go
@@ -40,7 +40,9 @@ var faultsListCmd = &cobra.Command{
 			faultsProjectID = viper.GetInt("project_id")
 		}
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -124,7 +126,9 @@ var faultsGetCmd = &cobra.Command{
 			faultsProjectID = viper.GetInt("project_id")
 		}
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")
@@ -209,7 +213,9 @@ var faultsNoticesCmd = &cobra.Command{
 			faultsProjectID = viper.GetInt("project_id")
 		}
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")
@@ -282,7 +288,9 @@ var faultsCountsCmd = &cobra.Command{
 			faultsProjectID = viper.GetInt("project_id")
 		}
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -344,7 +352,9 @@ var faultsAffectedUsersCmd = &cobra.Command{
 			faultsProjectID = viper.GetInt("project_id")
 		}
 		if faultsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")

--- a/cmd/faults.go
+++ b/cmd/faults.go
@@ -36,13 +36,8 @@ var faultsListCmd = &cobra.Command{
 	Short: "List faults for a project",
 	Long:  `List all faults for a specific project with optional filtering.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if faultsProjectID == 0 {
-			faultsProjectID = viper.GetInt("project_id")
-		}
-		if faultsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&faultsProjectID); err != nil {
+			return err
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -122,13 +117,8 @@ var faultsGetCmd = &cobra.Command{
 	Short: "Get a fault by ID",
 	Long:  `Get detailed information about a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if faultsProjectID == 0 {
-			faultsProjectID = viper.GetInt("project_id")
-		}
-		if faultsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&faultsProjectID); err != nil {
+			return err
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")
@@ -209,13 +199,8 @@ var faultsNoticesCmd = &cobra.Command{
 	Short: "List notices for a fault",
 	Long:  `List individual error occurrences (notices) for a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if faultsProjectID == 0 {
-			faultsProjectID = viper.GetInt("project_id")
-		}
-		if faultsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&faultsProjectID); err != nil {
+			return err
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")
@@ -284,13 +269,8 @@ var faultsCountsCmd = &cobra.Command{
 	Short: "Get fault counts for a project",
 	Long:  `Get summary counts of faults grouped by environment and status.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if faultsProjectID == 0 {
-			faultsProjectID = viper.GetInt("project_id")
-		}
-		if faultsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&faultsProjectID); err != nil {
+			return err
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -348,13 +328,8 @@ var faultsAffectedUsersCmd = &cobra.Command{
 	Short: "List users affected by a fault",
 	Long:  `List all users who have been affected by a specific fault.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if faultsProjectID == 0 {
-			faultsProjectID = viper.GetInt("project_id")
-		}
-		if faultsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&faultsProjectID); err != nil {
+			return err
 		}
 		if faultID == 0 {
 			return fmt.Errorf("fault ID is required. Set it using --id flag")

--- a/cmd/insights.go
+++ b/cmd/insights.go
@@ -49,7 +49,9 @@ Examples:
 			insightsProjectID = viper.GetInt("project_id")
 		}
 		if insightsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if insightsQuery == "" {
 			return fmt.Errorf("query is required. Set it using --query flag")

--- a/cmd/insights.go
+++ b/cmd/insights.go
@@ -45,13 +45,8 @@ Examples:
   # Query at a specific timestamp
   hb insights query --project-id 12345 --query "SELECT * FROM report.system.disk" --ts "2024-01-01T00:00:00Z"`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if insightsProjectID == 0 {
-			insightsProjectID = viper.GetInt("project_id")
-		}
-		if insightsProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&insightsProjectID); err != nil {
+			return err
 		}
 		if insightsQuery == "" {
 			return fmt.Errorf("query is required. Set it using --query flag")

--- a/cmd/insights.go
+++ b/cmd/insights.go
@@ -46,7 +46,10 @@ Examples:
   hb insights query --project-id 12345 --query "SELECT * FROM report.system.disk" --ts "2024-01-01T00:00:00Z"`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if insightsProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			insightsProjectID = viper.GetInt("project_id")
+		}
+		if insightsProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if insightsQuery == "" {
 			return fmt.Errorf("query is required. Set it using --query flag")
@@ -178,9 +181,6 @@ func init() {
 		StringVarP(&insightsOutputFormat, "output", "o", "table", "Output format (table or json)")
 
 	// Mark required flags
-	if err := insightsQueryCmd.MarkFlagRequired("project-id"); err != nil {
-		fmt.Printf("error marking project-id flag as required: %v\n", err)
-	}
 	if err := insightsQueryCmd.MarkFlagRequired("query"); err != nil {
 		fmt.Printf("error marking query flag as required: %v\n", err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -108,6 +108,11 @@ func initConfig() {
 	viper.SetEnvPrefix("HONEYBADGER")
 	viper.SetDefault("endpoint", defaultEndpoint)
 
+	// Register project_id for env var lookup (HONEYBADGER_PROJECT_ID).
+	// Unlike api_key/auth_token/endpoint, project_id has no root-level flag
+	// to bind, so we use BindEnv to make viper aware of it.
+	_ = viper.BindEnv("project_id")
+
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -154,6 +154,20 @@ func convertEndpointForDataAPI(endpoint string) string {
 	}
 }
 
+// resolveProjectID resolves the project ID from the flag value, falling back to viper config/env.
+// Returns an error if no project ID is found from any source.
+func resolveProjectID(projectID *int) error {
+	if *projectID == 0 {
+		*projectID = viper.GetInt("project_id")
+	}
+	if *projectID == 0 {
+		return fmt.Errorf(
+			"project ID is required. Set it using --project-id flag, HONEYBADGER_PROJECT_ID environment variable, or project_id in your config file",
+		)
+	}
+	return nil
+}
+
 // readJSONInput reads JSON from either a direct string or a file path prefixed with 'file://'
 func readJSONInput(input string) ([]byte, error) {
 	if strings.HasPrefix(input, "file://") {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -102,6 +102,25 @@ func TestResolveProjectID(t *testing.T) {
 	}
 }
 
+func TestResolveProjectIDFromEnvVar(t *testing.T) {
+	originalVal := os.Getenv("HONEYBADGER_PROJECT_ID")
+	defer func() {
+		_ = os.Setenv("HONEYBADGER_PROJECT_ID", originalVal)
+	}()
+
+	_ = os.Setenv("HONEYBADGER_PROJECT_ID", "456")
+
+	viper.Reset()
+	viper.SetEnvPrefix("HONEYBADGER")
+	viper.AutomaticEnv()
+	_ = viper.BindEnv("project_id")
+
+	projectID := 0
+	err := resolveProjectID(&projectID)
+	assert.NoError(t, err)
+	assert.Equal(t, 456, projectID)
+}
+
 func TestConfigurationLoading(t *testing.T) {
 	// Save original environment variables
 	originalAPIKey := os.Getenv("HONEYBADGER_API_KEY")

--- a/cmd/uptime.go
+++ b/cmd/uptime.go
@@ -44,7 +44,10 @@ var uptimeSitesListCmd = &cobra.Command{
 	Long:  `List all uptime monitoring sites configured for a specific project.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -103,7 +106,10 @@ var uptimeSitesGetCmd = &cobra.Command{
 	Long:  `Get detailed information about a specific uptime site.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -183,7 +189,10 @@ Available options:
 - locations: "Virginia", "Oregon", "Frankfurt", "Singapore", "London"`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if uptimeCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -256,7 +265,10 @@ Example JSON payload:
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -320,7 +332,10 @@ var uptimeSitesDeleteCmd = &cobra.Command{
 	Long:  `Delete an uptime monitoring site by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -357,7 +372,10 @@ var uptimeOutagesCmd = &cobra.Command{
 	Long:  `List outages recorded for a specific uptime monitoring site.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -429,7 +447,10 @@ var uptimeChecksCmd = &cobra.Command{
 	Long:  `List individual uptime checks performed for a specific site.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag")
+			uptimeProjectID = viper.GetInt("project_id")
+		}
+		if uptimeProjectID == 0 {
+			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")

--- a/cmd/uptime.go
+++ b/cmd/uptime.go
@@ -47,7 +47,9 @@ var uptimeSitesListCmd = &cobra.Command{
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -109,7 +111,9 @@ var uptimeSitesGetCmd = &cobra.Command{
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -192,7 +196,9 @@ Available options:
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if uptimeCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -268,7 +274,9 @@ Example JSON payload:
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -335,7 +343,9 @@ var uptimeSitesDeleteCmd = &cobra.Command{
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -375,7 +385,9 @@ var uptimeOutagesCmd = &cobra.Command{
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -450,7 +462,9 @@ var uptimeChecksCmd = &cobra.Command{
 			uptimeProjectID = viper.GetInt("project_id")
 		}
 		if uptimeProjectID == 0 {
-			return fmt.Errorf("project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable")
+			return fmt.Errorf(
+				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
+			)
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")

--- a/cmd/uptime.go
+++ b/cmd/uptime.go
@@ -43,13 +43,8 @@ var uptimeSitesListCmd = &cobra.Command{
 	Short: "List uptime sites for a project",
 	Long:  `List all uptime monitoring sites configured for a specific project.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 
 		authToken := viper.GetString("auth_token")
@@ -107,13 +102,8 @@ var uptimeSitesGetCmd = &cobra.Command{
 	Short: "Get an uptime site by ID",
 	Long:  `Get detailed information about a specific uptime site.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -192,13 +182,8 @@ Available options:
 - request_method: "GET", "POST", "PUT", "PATCH", "DELETE"
 - locations: "Virginia", "Oregon", "Frankfurt", "Singapore", "London"`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 		if uptimeCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
@@ -270,13 +255,8 @@ Example JSON payload:
   }
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -339,13 +319,8 @@ var uptimeSitesDeleteCmd = &cobra.Command{
 	Short: "Delete an uptime site",
 	Long:  `Delete an uptime monitoring site by ID. This action cannot be undone.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -381,13 +356,8 @@ var uptimeOutagesCmd = &cobra.Command{
 	Short: "List outages for a site",
 	Long:  `List outages recorded for a specific uptime monitoring site.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")
@@ -458,13 +428,8 @@ var uptimeChecksCmd = &cobra.Command{
 	Short: "List uptime checks for a site",
 	Long:  `List individual uptime checks performed for a specific site.`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if uptimeProjectID == 0 {
-			uptimeProjectID = viper.GetInt("project_id")
-		}
-		if uptimeProjectID == 0 {
-			return fmt.Errorf(
-				"project ID is required. Set it using --project-id flag or HONEYBADGER_PROJECT_ID environment variable",
-			)
+		if err := resolveProjectID(&uptimeProjectID); err != nil {
+			return err
 		}
 		if uptimeSiteID == "" {
 			return fmt.Errorf("site ID is required. Set it using --site-id flag")


### PR DESCRIPTION
## Summary
This PR adds support for configuring a default project ID through configuration files and environment variables, eliminating the need to specify `--project-id` flag for every command that requires it.

## Key Changes
- **Configuration Support**: Added `project_id` configuration option to YAML config files and `HONEYBADGER_PROJECT_ID` environment variable support
- **Fallback Logic**: Updated all Data API commands to fall back to the configured default project ID when the `--project-id` flag is not provided
- **Improved Error Messages**: Updated error messages to inform users they can set the project ID via flag, config file, or environment variable
- **Commands Updated**: Applied changes across all affected command files:
  - `cmd/checkins.go` (5 commands)
  - `cmd/comments.go` (5 commands)
  - `cmd/deployments.go` (3 commands)
  - `cmd/environments.go` (5 commands)
  - `cmd/faults.go` (5 commands)
  - `cmd/insights.go` (1 command, also removed redundant flag requirement)
  - `cmd/uptime.go` (7 commands)
- **Documentation**: Updated README.md with examples of the new configuration options

## Implementation Details
- The implementation uses Viper's `GetInt("project_id")` to retrieve the configured default value
- Each command checks if the project ID flag is zero, and if so, attempts to load it from configuration
- If still zero after the fallback, the command returns an error with updated guidance
- This maintains backward compatibility while providing a more convenient workflow for users working with a single project

https://claude.ai/code/session_01WT7m3r3dcygQtJYdacCnN7