### PR TITLE
Add alarms command for managing Insights alarms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `alarms` command for managing Insights alarms (list, get, create, update, delete, history)
+
 ## [0.7.0] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ These commands use `--auth-token` or `HONEYBADGER_AUTH_TOKEN` (personal auth tok
 | Command | Description |
 |---------|-------------|
 | `hb accounts` | Manage Honeybadger accounts and team members |
+| `hb alarms` | Manage Insights alarms for your projects |
 | `hb check-ins` | Manage check-ins for cron job and scheduled task monitoring |
 | `hb comments` | Manage comments on faults |
 | `hb deployments` | View and manage deployment history |

--- a/cmd/alarms.go
+++ b/cmd/alarms.go
@@ -1,0 +1,466 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	hbapi "github.com/honeybadger-io/api-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	alarmsProjectID    int
+	alarmID            string
+	alarmsOutputFormat string
+	alarmCLIInputJSON  string
+	alarmHistoryPage   int
+)
+
+// alarmsCmd represents the alarms command
+var alarmsCmd = &cobra.Command{
+	Use:     "alarms",
+	Short:   "Manage Honeybadger Insights alarms",
+	GroupID: GroupDataAPI,
+	Long:    `View and manage Insights alarms for your Honeybadger projects.`,
+}
+
+// alarmsListCmd represents the alarms list command
+var alarmsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List alarms for a project",
+	Long:  `List all Insights alarms configured for a specific project.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&alarmsProjectID); err != nil {
+			return err
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		ctx := context.Background()
+		response, err := client.Alarms.List(ctx, alarmsProjectID)
+		if err != nil {
+			return fmt.Errorf("failed to list alarms: %w", err)
+		}
+
+		switch alarmsOutputFormat {
+		case "json":
+			jsonBytes, err := json.MarshalIndent(response.Results, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal JSON: %w", err)
+			}
+			fmt.Println(string(jsonBytes))
+		default:
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tNAME\tSTATE\tQUERY\tEVAL PERIOD\tLAST CHECKED")
+			for _, alarm := range response.Results {
+				query := alarm.Query
+				if len(query) > 50 {
+					query = query[:47] + "..."
+				}
+
+				lastChecked := "Never"
+				if alarm.LastCheckedAt != nil {
+					lastChecked = alarm.LastCheckedAt.Format("2006-01-02 15:04")
+				}
+
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+					alarm.ID,
+					alarm.Name,
+					alarm.State,
+					query,
+					alarm.EvaluationPeriod,
+					lastChecked)
+			}
+			_ = w.Flush()
+		}
+
+		return nil
+	},
+}
+
+// alarmsGetCmd represents the alarms get command
+var alarmsGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get an alarm by ID",
+	Long:  `Get detailed information about a specific Insights alarm.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&alarmsProjectID); err != nil {
+			return err
+		}
+		if alarmID == "" {
+			return fmt.Errorf("alarm ID is required. Set it using --id flag")
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		ctx := context.Background()
+		alarm, err := client.Alarms.Get(ctx, alarmsProjectID, alarmID)
+		if err != nil {
+			return fmt.Errorf("failed to get alarm: %w", err)
+		}
+
+		switch alarmsOutputFormat {
+		case "json":
+			jsonBytes, err := json.MarshalIndent(alarm, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal JSON: %w", err)
+			}
+			fmt.Println(string(jsonBytes))
+		default:
+			fmt.Printf("Alarm Details:\n")
+			fmt.Printf("  ID: %s\n", alarm.ID)
+			fmt.Printf("  Name: %s\n", alarm.Name)
+			if alarm.Description != "" {
+				fmt.Printf("  Description: %s\n", alarm.Description)
+			}
+			fmt.Printf("  State: %s\n", alarm.State)
+			fmt.Printf("  Query: %s\n", alarm.Query)
+			if len(alarm.StreamIDs) > 0 {
+				fmt.Printf("  Stream IDs: %s\n", strings.Join(alarm.StreamIDs, ", "))
+			}
+			fmt.Printf("  Evaluation Period: %s\n", alarm.EvaluationPeriod)
+			if alarm.LookbackLag != "" {
+				fmt.Printf("  Lookback Lag: %s\n", alarm.LookbackLag)
+			}
+			if alarm.TriggerConfig != nil {
+				if triggerConfigJSON, err := json.Marshal(alarm.TriggerConfig); err == nil {
+					fmt.Printf("  Trigger Config: %s\n", string(triggerConfigJSON))
+				}
+			}
+			if alarm.Error != "" {
+				fmt.Printf("  Error: %s\n", alarm.Error)
+			}
+			if alarm.LastCheckedAt != nil {
+				fmt.Printf(
+					"  Last Checked: %s\n",
+					alarm.LastCheckedAt.Format("2006-01-02 15:04:05"),
+				)
+			}
+			if alarm.NextCheckAt != nil {
+				fmt.Printf("  Next Check: %s\n", alarm.NextCheckAt.Format("2006-01-02 15:04:05"))
+			}
+			fmt.Printf("  Created: %s\n", alarm.CreatedAt.Format("2006-01-02 15:04:05"))
+			fmt.Printf("  Updated: %s\n", alarm.UpdatedAt.Format("2006-01-02 15:04:05"))
+			if alarm.URL != "" {
+				fmt.Printf("  URL: %s\n", alarm.URL)
+			}
+		}
+
+		return nil
+	},
+}
+
+// alarmsCreateCmd represents the alarms create command
+var alarmsCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new alarm",
+	Long: `Create a new Insights alarm for a project.
+
+The --cli-input-json flag accepts either a JSON string or a file path prefixed with 'file://'.
+
+Example JSON payload:
+{
+  "alarm": {
+    "name": "High Error Rate",
+    "description": "Alert when errors spike",
+    "query": "filter event_type::str == \"notice\"",
+    "stream_ids": ["default"],
+    "evaluation_period": "5m",
+    "lookback_lag": "1m",
+    "trigger_config": {
+      "type": "alert_result_count",
+      "config": {"operator": "gt", "value": 10}
+    }
+  }
+}`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&alarmsProjectID); err != nil {
+			return err
+		}
+		if alarmCLIInputJSON == "" {
+			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		jsonData, err := readJSONInput(alarmCLIInputJSON)
+		if err != nil {
+			return fmt.Errorf("failed to read JSON input: %w", err)
+		}
+
+		var payload struct {
+			Alarm hbapi.AlarmRequest `json:"alarm"`
+		}
+		if err := json.Unmarshal(jsonData, &payload); err != nil {
+			return fmt.Errorf("failed to parse JSON payload: %w", err)
+		}
+
+		ctx := context.Background()
+		alarm, err := client.Alarms.Create(ctx, alarmsProjectID, payload.Alarm)
+		if err != nil {
+			return fmt.Errorf("failed to create alarm: %w", err)
+		}
+
+		switch alarmsOutputFormat {
+		case "json":
+			jsonBytes, err := json.MarshalIndent(alarm, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal JSON: %w", err)
+			}
+			fmt.Println(string(jsonBytes))
+		default:
+			fmt.Printf("Alarm created successfully!\n")
+			fmt.Printf("  ID: %s\n", alarm.ID)
+			fmt.Printf("  Name: %s\n", alarm.Name)
+			fmt.Printf("  State: %s\n", alarm.State)
+		}
+
+		return nil
+	},
+}
+
+// alarmsUpdateCmd represents the alarms update command
+var alarmsUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update an existing alarm",
+	Long: `Update an existing Insights alarm's settings.
+
+The --cli-input-json flag accepts either a JSON string or a file path prefixed with 'file://'.
+
+Example JSON payload:
+{
+  "alarm": {
+    "name": "Updated Alarm Name",
+    "query": "filter event_type::str == \"notice\"",
+    "evaluation_period": "10m",
+    "lookback_lag": "1m",
+    "trigger_config": {
+      "type": "alert_result_count",
+      "config": {"operator": "gt", "value": 25}
+    }
+  }
+}`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&alarmsProjectID); err != nil {
+			return err
+		}
+		if alarmID == "" {
+			return fmt.Errorf("alarm ID is required. Set it using --id flag")
+		}
+		if alarmCLIInputJSON == "" {
+			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		jsonData, err := readJSONInput(alarmCLIInputJSON)
+		if err != nil {
+			return fmt.Errorf("failed to read JSON input: %w", err)
+		}
+
+		var payload struct {
+			Alarm hbapi.AlarmRequest `json:"alarm"`
+		}
+		if err := json.Unmarshal(jsonData, &payload); err != nil {
+			return fmt.Errorf("failed to parse JSON payload: %w", err)
+		}
+
+		ctx := context.Background()
+		result, err := client.Alarms.Update(ctx, alarmsProjectID, alarmID, payload.Alarm)
+		if err != nil {
+			return fmt.Errorf("failed to update alarm: %w", err)
+		}
+
+		fmt.Println(result.Message)
+		return nil
+	},
+}
+
+// alarmsDeleteCmd represents the alarms delete command
+var alarmsDeleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete an alarm",
+	Long:  `Delete an Insights alarm by ID. This action cannot be undone.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&alarmsProjectID); err != nil {
+			return err
+		}
+		if alarmID == "" {
+			return fmt.Errorf("alarm ID is required. Set it using --id flag")
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		ctx := context.Background()
+		result, err := client.Alarms.Delete(ctx, alarmsProjectID, alarmID)
+		if err != nil {
+			return fmt.Errorf("failed to delete alarm: %w", err)
+		}
+
+		fmt.Println(result.Message)
+		return nil
+	},
+}
+
+// alarmsHistoryCmd represents the alarms history command
+var alarmsHistoryCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Get the trigger history for an alarm",
+	Long:  `Get the trigger history for a specific Insights alarm.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&alarmsProjectID); err != nil {
+			return err
+		}
+		if alarmID == "" {
+			return fmt.Errorf("alarm ID is required. Set it using --id flag")
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		ctx := context.Background()
+		response, err := client.Alarms.History(ctx, alarmsProjectID, alarmID, alarmHistoryPage)
+		if err != nil {
+			return fmt.Errorf("failed to get alarm history: %w", err)
+		}
+
+		switch alarmsOutputFormat {
+		case "json":
+			jsonBytes, err := json.MarshalIndent(response.Triggers, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal JSON: %w", err)
+			}
+			fmt.Println(string(jsonBytes))
+		default:
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tSTATE\tCREATED AT")
+			for _, trigger := range response.Triggers {
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n",
+					trigger.ID,
+					trigger.State,
+					trigger.CreatedAt.Format("2006-01-02 15:04:05"))
+			}
+			_ = w.Flush()
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(alarmsCmd)
+	alarmsCmd.AddCommand(alarmsListCmd)
+	alarmsCmd.AddCommand(alarmsGetCmd)
+	alarmsCmd.AddCommand(alarmsCreateCmd)
+	alarmsCmd.AddCommand(alarmsUpdateCmd)
+	alarmsCmd.AddCommand(alarmsDeleteCmd)
+	alarmsCmd.AddCommand(alarmsHistoryCmd)
+
+	// Common flags
+	alarmsCmd.PersistentFlags().IntVar(&alarmsProjectID, "project-id", 0, "Project ID")
+
+	// Flags for list command
+	alarmsListCmd.Flags().
+		StringVarP(&alarmsOutputFormat, "output", "o", "table", "Output format (table or json)")
+
+	// Flags for get command
+	alarmsGetCmd.Flags().StringVar(&alarmID, "id", "", "Alarm ID")
+	alarmsGetCmd.Flags().
+		StringVarP(&alarmsOutputFormat, "output", "o", "text", "Output format (text or json)")
+	_ = alarmsGetCmd.MarkFlagRequired("id")
+
+	// Flags for create command
+	alarmsCreateCmd.Flags().
+		StringVar(&alarmCLIInputJSON, "cli-input-json", "", "JSON payload (string or file://path)")
+	alarmsCreateCmd.Flags().
+		StringVarP(&alarmsOutputFormat, "output", "o", "text", "Output format (text or json)")
+	_ = alarmsCreateCmd.MarkFlagRequired("cli-input-json")
+
+	// Flags for update command
+	alarmsUpdateCmd.Flags().StringVar(&alarmID, "id", "", "Alarm ID")
+	alarmsUpdateCmd.Flags().
+		StringVar(&alarmCLIInputJSON, "cli-input-json", "", "JSON payload (string or file://path)")
+	_ = alarmsUpdateCmd.MarkFlagRequired("id")
+	_ = alarmsUpdateCmd.MarkFlagRequired("cli-input-json")
+
+	// Flags for delete command
+	alarmsDeleteCmd.Flags().StringVar(&alarmID, "id", "", "Alarm ID")
+	_ = alarmsDeleteCmd.MarkFlagRequired("id")
+
+	// Flags for history command
+	alarmsHistoryCmd.Flags().StringVar(&alarmID, "id", "", "Alarm ID")
+	alarmsHistoryCmd.Flags().IntVar(&alarmHistoryPage, "page", 0, "Page number for pagination")
+	alarmsHistoryCmd.Flags().
+		StringVarP(&alarmsOutputFormat, "output", "o", "table", "Output format (table or json)")
+	_ = alarmsHistoryCmd.MarkFlagRequired("id")
+}

--- a/cmd/alarms.go
+++ b/cmd/alarms.go
@@ -185,13 +185,17 @@ var alarmsCreateCmd = &cobra.Command{
 
 The --cli-input-json flag accepts either a JSON string or a file path prefixed with 'file://'.
 
+stream_ids is required and must be a non-empty array of the project's Insights stream
+IDs; an empty or omitted value is rejected by the API. Find the IDs in the Insights UI
+or via a BadgerQL query like "stats count() by @stream.id, @stream.name".
+
 Example JSON payload:
 {
   "alarm": {
     "name": "High Error Rate",
     "description": "Alert when errors spike",
     "query": "filter event_type::str == \"notice\"",
-    "stream_ids": ["default"],
+    "stream_ids": ["<stream-id>"],
     "evaluation_period": "5m",
     "lookback_lag": "1m",
     "trigger_config": {
@@ -265,11 +269,16 @@ var alarmsUpdateCmd = &cobra.Command{
 
 The --cli-input-json flag accepts either a JSON string or a file path prefixed with 'file://'.
 
+stream_ids is required and must be a non-empty array of the project's Insights stream
+IDs; an empty or omitted value is rejected by the API. Find the IDs in the Insights UI
+or via a BadgerQL query like "stats count() by @stream.id, @stream.name".
+
 Example JSON payload:
 {
   "alarm": {
     "name": "Updated Alarm Name",
     "query": "filter event_type::str == \"notice\"",
+    "stream_ids": ["<stream-id>"],
     "evaluation_period": "10m",
     "lookback_lag": "1m",
     "trigger_config": {

--- a/cmd/alarms_test.go
+++ b/cmd/alarms_test.go
@@ -1,0 +1,317 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlarmsListCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		projectIDValue int
+		authToken      string
+		serverStatus   int
+		serverBody     string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "successful list",
+			projectIDValue: 123,
+			authToken:      "test-token",
+			serverStatus:   http.StatusOK,
+			serverBody: `{
+				"results": [{"id": "alarm-1", "name": "High Error Rate", "state": "ok", "query": "filter event_type::str == \"notice\"", "evaluation_period": "5m"}],
+				"links": {"self": "/v2/projects/123/alarms"}
+			}`,
+			expectedError: false,
+		},
+		{
+			name:           "missing project ID",
+			projectIDValue: 0,
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "project ID is required",
+		},
+		{
+			name:           "missing auth token",
+			projectIDValue: 123,
+			authToken:      "",
+			expectedError:  true,
+			errorContains:  "auth token is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverURL string
+			if tt.authToken != "" && tt.projectIDValue != 0 {
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "GET", r.Method)
+
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tt.serverStatus)
+						_, _ = w.Write([]byte(tt.serverBody))
+					}),
+				)
+				defer server.Close()
+				serverURL = server.URL
+			} else {
+				serverURL = "http://localhost:9999"
+			}
+
+			viper.Reset()
+			viper.Set("endpoint", serverURL)
+			if tt.authToken != "" {
+				viper.Set("auth_token", tt.authToken)
+			}
+
+			alarmsProjectID = tt.projectIDValue
+			alarmsOutputFormat = "table"
+
+			err := alarmsListCmd.RunE(alarmsListCmd, []string{})
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAlarmsGetCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		projectIDValue int
+		alarmIDValue   string
+		authToken      string
+		serverStatus   int
+		serverBody     string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "successful get",
+			projectIDValue: 123,
+			alarmIDValue:   "alarm-1",
+			authToken:      "test-token",
+			serverStatus:   http.StatusOK,
+			serverBody: `{
+				"id": "alarm-1",
+				"name": "High Error Rate",
+				"state": "ok",
+				"query": "filter event_type::str == \"notice\"",
+				"evaluation_period": "5m",
+				"trigger_config": {"type": "alert_result_count", "config": {"operator": "gt", "value": 10}}
+			}`,
+			expectedError: false,
+		},
+		{
+			name:           "missing project ID",
+			projectIDValue: 0,
+			alarmIDValue:   "alarm-1",
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "project ID is required",
+		},
+		{
+			name:           "missing alarm ID",
+			projectIDValue: 123,
+			alarmIDValue:   "",
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "alarm ID is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverURL string
+			if tt.authToken != "" && tt.projectIDValue != 0 && tt.alarmIDValue != "" {
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "GET", r.Method)
+
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tt.serverStatus)
+						_, _ = w.Write([]byte(tt.serverBody))
+					}),
+				)
+				defer server.Close()
+				serverURL = server.URL
+			} else {
+				serverURL = "http://localhost:9999"
+			}
+
+			viper.Reset()
+			viper.Set("endpoint", serverURL)
+			if tt.authToken != "" {
+				viper.Set("auth_token", tt.authToken)
+			}
+
+			alarmsProjectID = tt.projectIDValue
+			alarmID = tt.alarmIDValue
+			alarmsOutputFormat = "text"
+
+			err := alarmsGetCmd.RunE(alarmsGetCmd, []string{})
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAlarmsHistoryCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		projectIDValue int
+		alarmIDValue   string
+		authToken      string
+		serverStatus   int
+		serverBody     string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "successful history",
+			projectIDValue: 123,
+			alarmIDValue:   "alarm-1",
+			authToken:      "test-token",
+			serverStatus:   http.StatusOK,
+			serverBody: `{
+				"triggers": [{"id": "trigger-1", "state": "alarm", "result": {"count": 42}, "created_at": "2024-01-01T00:00:00Z"}],
+				"links": {"self": "/v2/projects/123/alarms/alarm-1/history"}
+			}`,
+			expectedError: false,
+		},
+		{
+			name:           "missing alarm ID",
+			projectIDValue: 123,
+			alarmIDValue:   "",
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "alarm ID is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverURL string
+			if tt.authToken != "" && tt.projectIDValue != 0 && tt.alarmIDValue != "" {
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "GET", r.Method)
+
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tt.serverStatus)
+						_, _ = w.Write([]byte(tt.serverBody))
+					}),
+				)
+				defer server.Close()
+				serverURL = server.URL
+			} else {
+				serverURL = "http://localhost:9999"
+			}
+
+			viper.Reset()
+			viper.Set("endpoint", serverURL)
+			if tt.authToken != "" {
+				viper.Set("auth_token", tt.authToken)
+			}
+
+			alarmsProjectID = tt.projectIDValue
+			alarmID = tt.alarmIDValue
+			alarmHistoryPage = 0
+			alarmsOutputFormat = "table"
+
+			err := alarmsHistoryCmd.RunE(alarmsHistoryCmd, []string{})
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAlarmsViperProjectIDFallback(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"results": [{"id": "alarm-1", "name": "High Error Rate", "state": "ok", "query": "filter event_type::str == \"notice\"", "evaluation_period": "5m"}],
+				"links": {"self": "/v2/projects/123/alarms"}
+			}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+	viper.Set("project_id", 123)
+
+	alarmsProjectID = 0
+	alarmsOutputFormat = "table"
+
+	err := alarmsListCmd.RunE(alarmsListCmd, []string{})
+	assert.NoError(t, err)
+}
+
+func TestAlarmsOutputFormat(t *testing.T) {
+	mockResponse := `{
+		"results": [{"id": "alarm-1", "name": "High Error Rate", "state": "ok", "query": "filter event_type::str == \"notice\"", "evaluation_period": "5m"}],
+		"links": {"self": "/v2/projects/123/alarms"}
+	}`
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(mockResponse))
+		}),
+	)
+	defer server.Close()
+
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{name: "table format", format: "table"},
+		{name: "json format", format: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			viper.Set("endpoint", server.URL)
+			viper.Set("auth_token", "test-token")
+
+			alarmsProjectID = 123
+			alarmsOutputFormat = tt.format
+
+			err := alarmsListCmd.RunE(alarmsListCmd, []string{})
+			assert.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `hb alarms` command group for managing Honeybadger **Insights alarms**, bringing the CLI to parity with the [`api-go`](https://github.com/honeybadger-io/api-go) client and the [MCP server](https://github.com/honeybadger-io/honeybadger-mcp-server), both of which already support alarms.

Subcommands:

| Command | Endpoint |
|---------|----------|
| `hb alarms list` | `GET /v2/projects/{id}/alarms` |
| `hb alarms get` | `GET /v2/projects/{id}/alarms/{id}` |
| `hb alarms create` | `POST /v2/projects/{id}/alarms` |
| `hb alarms update` | `PUT /v2/projects/{id}/alarms/{id}` |
| `hb alarms delete` | `DELETE /v2/projects/{id}/alarms/{id}` |
| `hb alarms history` | `GET /v2/projects/{id}/alarms/{id}/history` |

## Details

- Backed by `api-go`'s `AlarmsService` (`client.Alarms`).
- Follows the existing project-scoped command pattern (modeled on `check-ins`): reuses `resolveProjectID` (so `--project-id`, `HONEYBADGER_PROJECT_ID`, and config all work), `readJSONInput` (`--cli-input-json` accepts a string or `file://path`), and the `--output` (table/text/json) convention.
- `create`/`update` wrap the request body in the `alarm` object, matching the Data API.
- `update`/`delete` surface the API's result message (as `projects` does); `history` supports `--page`.
- Verified field names, required/optional flags, and the `trigger_config` schema against the [Insights alarms API reference](https://deploy-preview-815--honeybadger-docs.netlify.app/api/alarms/).

## Testing

- New `cmd/alarms_test.go` mirrors `cmd/checkins_test.go` (list/get/history success + missing-arg cases, viper project-id fallback, table/json output).
- `go build ./...`, `go test ./...`, and `golangci-lint run` (v2.10.1, repo config) all pass.

Opened as a **draft** for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
