### PR TITLE
feat: add commands for api-go v0.8.0 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add `streams` command for listing Insights streams
+- Add `faults update` command for resolving, ignoring, assigning, and marking faults to resolve on deploy
+- Add `--stream-ids` flag to `insights query` to restrict queries to specific streams
+
+### Changed
+
+- `projects create` no longer requires `--account-id`; when omitted, the project is created in the first account the auth token has access to
+
 ## [0.8.0] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ These commands use `--auth-token` or `HONEYBADGER_AUTH_TOKEN` (personal auth tok
 | `hb insights` | Execute BadgerQL queries against your Insights data |
 | `hb projects` | Manage Honeybadger projects |
 | `hb statuspages` | Manage public status pages |
+| `hb streams` | View Insights data streams for your projects |
 | `hb teams` | Manage teams and team memberships |
 | `hb uptime` | Manage uptime monitoring checks |
 
@@ -147,6 +148,12 @@ hb insights query --project-id 12345 --query "fields @ts, @preview | sort @ts"
 
 # List faults for a project
 hb faults list --project-id 12345
+
+# Resolve a fault
+hb faults update --project-id 12345 --id 678 --resolved
+
+# List Insights streams for a project
+hb streams list --project-id 12345
 ```
 
 See the [Honeybadger CLI documentation](https://docs.honeybadger.io/resources/cli/) for more information.

--- a/cmd/faults.go
+++ b/cmd/faults.go
@@ -20,6 +20,11 @@ var (
 	faultLimit             int
 	faultOutputFormat      string
 	faultAffectedUserQuery string
+	faultResolved          bool
+	faultIgnored           bool
+	faultResolveOnDeploy   bool
+	faultAssigneeID        int
+	faultUnassign          bool
 )
 
 // faultsCmd represents the faults command
@@ -263,6 +268,94 @@ var faultsNoticesCmd = &cobra.Command{
 	},
 }
 
+// faultsUpdateCmd represents the faults update command
+var faultsUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Update a fault's state",
+	Long: `Update a fault's resolved, ignored, assignee, or resolve-on-deploy state.
+
+Only the flags you pass are updated; other fields are left unchanged. Setting
+--resolved or --ignored to true in the same request takes precedence over
+--resolve-on-deploy.
+
+Examples:
+  # Resolve a fault
+  hb faults update --project-id 12345 --id 678 --resolved
+
+  # Un-resolve a fault
+  hb faults update --project-id 12345 --id 678 --resolved=false
+
+  # Ignore a fault
+  hb faults update --project-id 12345 --id 678 --ignored
+
+  # Mark a fault to be resolved automatically on the next deploy
+  hb faults update --project-id 12345 --id 678 --resolve-on-deploy
+
+  # Assign a fault to a user
+  hb faults update --project-id 12345 --id 678 --assignee-id 42
+
+  # Unassign a fault
+  hb faults update --project-id 12345 --id 678 --unassign`,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&faultsProjectID); err != nil {
+			return err
+		}
+		if faultID == 0 {
+			return fmt.Errorf("fault ID is required. Set it using --id flag")
+		}
+		if faultAssigneeID != 0 && faultUnassign {
+			return fmt.Errorf("--assignee-id and --unassign are mutually exclusive")
+		}
+
+		params := hbapi.FaultUpdateParams{}
+		if cmd.Flags().Changed("resolved") {
+			params.Resolved = &faultResolved
+		}
+		if cmd.Flags().Changed("ignored") {
+			params.Ignored = &faultIgnored
+		}
+		if cmd.Flags().Changed("resolve-on-deploy") {
+			params.ResolveOnDeploy = &faultResolveOnDeploy
+		}
+		if faultAssigneeID != 0 {
+			params.AssigneeID = hbapi.Value(faultAssigneeID)
+		} else if faultUnassign {
+			params.AssigneeID = hbapi.Null[int]()
+		}
+
+		if params.Resolved == nil && params.Ignored == nil && params.ResolveOnDeploy == nil &&
+			params.AssigneeID == nil {
+			return fmt.Errorf(
+				"nothing to update. Set at least one of --resolved, --ignored, --resolve-on-deploy, --assignee-id, or --unassign",
+			)
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		// Create API client
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		ctx := context.Background()
+		result, err := client.Faults.Update(ctx, faultsProjectID, faultID, params)
+		if err != nil {
+			return fmt.Errorf("failed to update fault: %w", err)
+		}
+
+		fmt.Println(result.Message)
+
+		return nil
+	},
+}
+
 // faultsCountsCmd represents the faults counts command
 var faultsCountsCmd = &cobra.Command{
 	Use:   "counts",
@@ -386,6 +479,7 @@ func init() {
 	rootCmd.AddCommand(faultsCmd)
 	faultsCmd.AddCommand(faultsListCmd)
 	faultsCmd.AddCommand(faultsGetCmd)
+	faultsCmd.AddCommand(faultsUpdateCmd)
 	faultsCmd.AddCommand(faultsNoticesCmd)
 	faultsCmd.AddCommand(faultsCountsCmd)
 	faultsCmd.AddCommand(faultsAffectedUsersCmd)
@@ -407,6 +501,19 @@ func init() {
 	faultsGetCmd.Flags().
 		StringVarP(&faultOutputFormat, "output", "o", "text", "Output format (text or json)")
 
+	// Flags for update command
+	faultsUpdateCmd.Flags().IntVar(&faultID, "id", 0, "Fault ID")
+	faultsUpdateCmd.Flags().
+		BoolVar(&faultResolved, "resolved", false, "Set the fault's resolved state (use --resolved=false to un-resolve)")
+	faultsUpdateCmd.Flags().
+		BoolVar(&faultIgnored, "ignored", false, "Set the fault's ignored state (use --ignored=false to un-ignore)")
+	faultsUpdateCmd.Flags().
+		BoolVar(&faultResolveOnDeploy, "resolve-on-deploy", false, "Mark the fault to be resolved automatically on the next deploy")
+	faultsUpdateCmd.Flags().
+		IntVar(&faultAssigneeID, "assignee-id", 0, "User ID to assign the fault to")
+	faultsUpdateCmd.Flags().
+		BoolVar(&faultUnassign, "unassign", false, "Remove the fault's assignee")
+
 	// Flags for notices command
 	faultsNoticesCmd.Flags().IntVar(&faultID, "id", 0, "Fault ID")
 	faultsNoticesCmd.Flags().
@@ -427,6 +534,9 @@ func init() {
 
 	// Mark required flags
 	if err := faultsGetCmd.MarkFlagRequired("id"); err != nil {
+		fmt.Printf("error marking id flag as required: %v\n", err)
+	}
+	if err := faultsUpdateCmd.MarkFlagRequired("id"); err != nil {
 		fmt.Printf("error marking id flag as required: %v\n", err)
 	}
 	if err := faultsNoticesCmd.MarkFlagRequired("id"); err != nil {

--- a/cmd/faults.go
+++ b/cmd/faults.go
@@ -274,9 +274,9 @@ var faultsUpdateCmd = &cobra.Command{
 	Short: "Update a fault's state",
 	Long: `Update a fault's resolved, ignored, assignee, or resolve-on-deploy state.
 
-Only the flags you pass are updated; other fields are left unchanged. Setting
---resolved or --ignored to true in the same request takes precedence over
---resolve-on-deploy.
+Only the flags you pass are updated; other fields are left unchanged. Note that
+when --resolved or --ignored is set to true in the same request as
+--resolve-on-deploy, the API gives the former precedence.
 
 Examples:
   # Resolve a fault

--- a/cmd/faults_test.go
+++ b/cmd/faults_test.go
@@ -1,0 +1,233 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// resetFaultUpdateFlags clears flag values and Changed state between test runs
+func resetFaultUpdateFlags(t *testing.T) {
+	t.Helper()
+
+	faultResolved = false
+	faultIgnored = false
+	faultResolveOnDeploy = false
+	faultAssigneeID = 0
+	faultUnassign = false
+
+	for _, name := range []string{"resolved", "ignored", "resolve-on-deploy"} {
+		flag := faultsUpdateCmd.Flags().Lookup(name)
+		require.NotNil(t, flag)
+		flag.Changed = false
+	}
+}
+
+func TestFaultsUpdateCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		projectIDValue int
+		faultIDValue   int
+		authToken      string
+		setFlags       map[string]string
+		assigneeID     int
+		unassign       bool
+		expectedBody   string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "resolve fault",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			setFlags:       map[string]string{"resolved": "true"},
+			expectedBody:   `{"fault":{"resolved":true}}`,
+			expectedError:  false,
+		},
+		{
+			name:           "un-resolve fault",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			setFlags:       map[string]string{"resolved": "false"},
+			expectedBody:   `{"fault":{"resolved":false}}`,
+			expectedError:  false,
+		},
+		{
+			name:           "ignore fault",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			setFlags:       map[string]string{"ignored": "true"},
+			expectedBody:   `{"fault":{"ignored":true}}`,
+			expectedError:  false,
+		},
+		{
+			name:           "resolve on deploy",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			setFlags:       map[string]string{"resolve-on-deploy": "true"},
+			expectedBody:   `{"fault":{"resolve_on_deploy":true}}`,
+			expectedError:  false,
+		},
+		{
+			name:           "assign fault",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			assigneeID:     42,
+			expectedBody:   `{"fault":{"assignee_id":42}}`,
+			expectedError:  false,
+		},
+		{
+			name:           "unassign fault",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			unassign:       true,
+			expectedBody:   `{"fault":{"assignee_id":null}}`,
+			expectedError:  false,
+		},
+		{
+			name:           "missing project ID",
+			projectIDValue: 0,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			setFlags:       map[string]string{"resolved": "true"},
+			expectedError:  true,
+			errorContains:  "project ID is required",
+		},
+		{
+			name:           "missing fault ID",
+			projectIDValue: 123,
+			faultIDValue:   0,
+			authToken:      "test-token",
+			setFlags:       map[string]string{"resolved": "true"},
+			expectedError:  true,
+			errorContains:  "fault ID is required",
+		},
+		{
+			name:           "nothing to update",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "nothing to update",
+		},
+		{
+			name:           "assignee-id and unassign are mutually exclusive",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "test-token",
+			assigneeID:     42,
+			unassign:       true,
+			expectedError:  true,
+			errorContains:  "mutually exclusive",
+		},
+		{
+			name:           "missing auth token",
+			projectIDValue: 123,
+			faultIDValue:   456,
+			authToken:      "",
+			setFlags:       map[string]string{"resolved": "true"},
+			expectedError:  true,
+			errorContains:  "auth token is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverURL string
+			if !tt.expectedError {
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "PUT", r.Method)
+						assert.Equal(t, "/v2/projects/123/faults/456", r.URL.Path)
+
+						body, err := io.ReadAll(r.Body)
+						require.NoError(t, err)
+						assert.JSONEq(t, tt.expectedBody, string(body))
+
+						w.WriteHeader(http.StatusNoContent)
+					}),
+				)
+				defer server.Close()
+				serverURL = server.URL
+			} else {
+				serverURL = "http://localhost:9999"
+			}
+
+			viper.Reset()
+			viper.Set("endpoint", serverURL)
+			if tt.authToken != "" {
+				viper.Set("auth_token", tt.authToken)
+			}
+
+			resetFaultUpdateFlags(t)
+			faultsProjectID = tt.projectIDValue
+			faultID = tt.faultIDValue
+			faultAssigneeID = tt.assigneeID
+			faultUnassign = tt.unassign
+			for name, value := range tt.setFlags {
+				require.NoError(t, faultsUpdateCmd.Flags().Set(name, value))
+			}
+
+			err := faultsUpdateCmd.RunE(faultsUpdateCmd, []string{})
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInsightsQueryStreamIDs(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "POST", r.Method)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var request map[string]interface{}
+			require.NoError(t, json.Unmarshal(body, &request))
+			assert.Equal(t, []interface{}{"abc123", "def456"}, request["stream_ids"])
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"meta": {"query": "fields @ts", "fields": [], "rows": 0, "total_rows": 0},
+				"results": []
+			}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+
+	insightsProjectID = 123
+	insightsQuery = "fields @ts"
+	insightsTimestamp = ""
+	insightsTimezone = ""
+	insightsStreamIDs = []string{"abc123", "def456"}
+	insightsOutputFormat = "table"
+	defer func() { insightsStreamIDs = nil }()
+
+	err := insightsQueryCmd.RunE(insightsQueryCmd, []string{})
+	assert.NoError(t, err)
+}

--- a/cmd/insights.go
+++ b/cmd/insights.go
@@ -18,6 +18,7 @@ var (
 	insightsQuery        string
 	insightsTimestamp    string
 	insightsTimezone     string
+	insightsStreamIDs    []string
 	insightsOutputFormat string
 )
 
@@ -43,7 +44,10 @@ Examples:
   hb insights query --project-id 12345 --query "SELECT * FROM report.system.memory" --timezone "America/New_York"
 
   # Query at a specific timestamp
-  hb insights query --project-id 12345 --query "SELECT * FROM report.system.disk" --ts "2024-01-01T00:00:00Z"`,
+  hb insights query --project-id 12345 --query "SELECT * FROM report.system.disk" --ts "2024-01-01T00:00:00Z"
+
+  # Restrict the query to specific streams (find IDs with 'hb streams list')
+  hb insights query --project-id 12345 --query "fields @ts, @message" --stream-ids "abc123,def456"`,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if err := resolveProjectID(&insightsProjectID); err != nil {
 			return err
@@ -68,9 +72,10 @@ Examples:
 
 		// Build request
 		request := hbapi.InsightsQueryRequest{
-			Query:    insightsQuery,
-			Ts:       insightsTimestamp,
-			Timezone: insightsTimezone,
+			Query:     insightsQuery,
+			Ts:        insightsTimestamp,
+			Timezone:  insightsTimezone,
+			StreamIDs: insightsStreamIDs,
 		}
 
 		ctx := context.Background()
@@ -174,6 +179,8 @@ func init() {
 		StringVar(&insightsTimestamp, "ts", "", "Timestamp for the query (RFC3339 format)")
 	insightsQueryCmd.Flags().
 		StringVar(&insightsTimezone, "timezone", "", "Timezone for the query (e.g., 'America/New_York')")
+	insightsQueryCmd.Flags().
+		StringSliceVar(&insightsStreamIDs, "stream-ids", nil, "Restrict the query to specific stream IDs (comma-separated; see 'hb streams list')")
 	insightsQueryCmd.Flags().
 		StringVarP(&insightsOutputFormat, "output", "o", "table", "Output format (table or json)")
 

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -182,7 +182,10 @@ var projectsGetCmd = &cobra.Command{
 var projectsCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new project",
-	Long: `Create a new project in a specific account.
+	Long: `Create a new project.
+
+If --account-id is omitted, the project is created in the first account your
+auth token has access to.
 
 The --cli-input-json flag accepts either a JSON string or a file path prefixed with 'file://'.
 
@@ -200,9 +203,6 @@ Example JSON payload:
   }
 }`,
 	RunE: func(_ *cobra.Command, _ []string) error {
-		if projectAccountID == "" {
-			return fmt.Errorf("account ID is required. Set it using --account-id flag")
-		}
 		if projectCLIInputJSON == "" {
 			return fmt.Errorf("JSON payload is required. Set it using --cli-input-json flag")
 		}
@@ -620,15 +620,12 @@ func init() {
 
 	// Flags for create command
 	projectsCreateCmd.Flags().
-		StringVar(&projectAccountID, "account-id", "", "Account ID to create project in")
+		StringVar(&projectAccountID, "account-id", "", "Account ID to create project in (defaults to the first account your auth token can access)")
 	projectsCreateCmd.Flags().
 		StringVar(&projectCLIInputJSON, "cli-input-json", "", "JSON payload (string or file://path)")
 	projectsCreateCmd.Flags().
 		StringVarP(&projectOutputFormat, "output", "o", "text", "Output format (text or json)")
 
-	if err := projectsCreateCmd.MarkFlagRequired("account-id"); err != nil {
-		fmt.Printf("error marking account-id flag as required: %v\n", err)
-	}
 	if err := projectsCreateCmd.MarkFlagRequired("cli-input-json"); err != nil {
 		fmt.Printf("error marking cli-input-json flag as required: %v\n", err)
 	}

--- a/cmd/projects_test.go
+++ b/cmd/projects_test.go
@@ -71,9 +71,7 @@ func TestProjectsCreateCommand(t *testing.T) {
 
 						w.Header().Set("Content-Type", "application/json")
 						w.WriteHeader(http.StatusCreated)
-						_, _ = w.Write(
-							[]byte(`{"id": 123, "name": "My Project", "created_at": "2024-01-01T00:00:00Z"}`),
-						)
+						_, _ = w.Write([]byte(`{"id": 123, "name": "My Project"}`))
 					}),
 				)
 				defer server.Close()

--- a/cmd/projects_test.go
+++ b/cmd/projects_test.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectsCreateCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		accountIDValue string
+		cliInputJSON   string
+		authToken      string
+		expectedRawQ   string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "create with account ID",
+			accountIDValue: "K7xmQq",
+			cliInputJSON:   `{"project": {"name": "My Project"}}`,
+			authToken:      "test-token",
+			expectedRawQ:   "account_id=K7xmQq",
+			expectedError:  false,
+		},
+		{
+			name:           "create without account ID omits query param",
+			accountIDValue: "",
+			cliInputJSON:   `{"project": {"name": "My Project"}}`,
+			authToken:      "test-token",
+			expectedRawQ:   "",
+			expectedError:  false,
+		},
+		{
+			name:           "missing JSON payload",
+			accountIDValue: "K7xmQq",
+			cliInputJSON:   "",
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "JSON payload is required",
+		},
+		{
+			name:           "missing auth token",
+			accountIDValue: "K7xmQq",
+			cliInputJSON:   `{"project": {"name": "My Project"}}`,
+			authToken:      "",
+			expectedError:  true,
+			errorContains:  "auth token is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverURL string
+			if !tt.expectedError {
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "POST", r.Method)
+						assert.Equal(t, "/v2/projects", r.URL.Path)
+						assert.Equal(t, tt.expectedRawQ, r.URL.RawQuery)
+
+						body, err := io.ReadAll(r.Body)
+						require.NoError(t, err)
+						assert.JSONEq(t, `{"project": {"name": "My Project"}}`, string(body))
+
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusCreated)
+						_, _ = w.Write(
+							[]byte(`{"id": 123, "name": "My Project", "created_at": "2024-01-01T00:00:00Z"}`),
+						)
+					}),
+				)
+				defer server.Close()
+				serverURL = server.URL
+			} else {
+				serverURL = "http://localhost:9999"
+			}
+
+			viper.Reset()
+			viper.Set("endpoint", serverURL)
+			if tt.authToken != "" {
+				viper.Set("auth_token", tt.authToken)
+			}
+
+			projectAccountID = tt.accountIDValue
+			projectCLIInputJSON = tt.cliInputJSON
+			projectOutputFormat = "text"
+
+			err := projectsCreateCmd.RunE(projectsCreateCmd, []string{})
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/cmd/streams.go
+++ b/cmd/streams.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	hbapi "github.com/honeybadger-io/api-go"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	streamsProjectID    int
+	streamsOutputFormat string
+)
+
+// streamsCmd represents the streams command
+var streamsCmd = &cobra.Command{
+	Use:     "streams",
+	Short:   "Manage Insights streams",
+	GroupID: GroupDataAPI,
+	Long:    `View Insights data streams for your Honeybadger projects.`,
+}
+
+// streamsListCmd represents the streams list command
+var streamsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List streams for a project",
+	Long: `List all Insights data streams for a specific project.
+
+Stream IDs can be used to scope Insights queries (hb insights query --stream-ids)
+and alarms to specific streams.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if err := resolveProjectID(&streamsProjectID); err != nil {
+			return err
+		}
+
+		authToken := viper.GetString("auth_token")
+		if authToken == "" {
+			return fmt.Errorf(
+				"auth token is required. Set it using --auth-token flag or HONEYBADGER_AUTH_TOKEN environment variable",
+			)
+		}
+
+		endpoint := convertEndpointForDataAPI(viper.GetString("endpoint"))
+
+		client := hbapi.NewClient().
+			WithBaseURL(endpoint).
+			WithAuthToken(authToken)
+
+		ctx := context.Background()
+		streams, err := client.Streams.List(ctx, streamsProjectID)
+		if err != nil {
+			return fmt.Errorf("failed to list streams: %w", err)
+		}
+
+		switch streamsOutputFormat {
+		case "json":
+			jsonBytes, err := json.MarshalIndent(streams, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal JSON: %w", err)
+			}
+			fmt.Println(string(jsonBytes))
+		default:
+			w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			_, _ = fmt.Fprintln(w, "ID\tNAME\tSLUG\tINTERNAL\tCREATED")
+			for _, stream := range streams {
+				internal := " "
+				if stream.Internal {
+					internal = "✓"
+				}
+
+				_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+					stream.ID,
+					stream.Name,
+					stream.Slug,
+					internal,
+					stream.CreatedAt.Format("2006-01-02 15:04"))
+			}
+			_ = w.Flush()
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(streamsCmd)
+	streamsCmd.AddCommand(streamsListCmd)
+
+	// Common flags
+	streamsCmd.PersistentFlags().IntVar(&streamsProjectID, "project-id", 0, "Project ID")
+
+	// Flags for list command
+	streamsListCmd.Flags().
+		StringVarP(&streamsOutputFormat, "output", "o", "table", "Output format (table or json)")
+}

--- a/cmd/streams_test.go
+++ b/cmd/streams_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStreamsListCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		projectIDValue int
+		authToken      string
+		serverStatus   int
+		serverBody     string
+		expectedError  bool
+		errorContains  string
+	}{
+		{
+			name:           "successful list",
+			projectIDValue: 123,
+			authToken:      "test-token",
+			serverStatus:   http.StatusOK,
+			serverBody: `{
+				"results": [{"id": "abc123", "name": "Rails Logs", "slug": "rails-logs", "internal": false, "project_id": 123, "created_at": "2024-01-01T00:00:00Z"}]
+			}`,
+			expectedError: false,
+		},
+		{
+			name:           "missing project ID",
+			projectIDValue: 0,
+			authToken:      "test-token",
+			expectedError:  true,
+			errorContains:  "project ID is required",
+		},
+		{
+			name:           "missing auth token",
+			projectIDValue: 123,
+			authToken:      "",
+			expectedError:  true,
+			errorContains:  "auth token is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var serverURL string
+			if tt.authToken != "" && tt.projectIDValue != 0 {
+				server := httptest.NewServer(
+					http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "GET", r.Method)
+						assert.Equal(t, "/v2/projects/123/streams", r.URL.Path)
+
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(tt.serverStatus)
+						_, _ = w.Write([]byte(tt.serverBody))
+					}),
+				)
+				defer server.Close()
+				serverURL = server.URL
+			} else {
+				serverURL = "http://localhost:9999"
+			}
+
+			viper.Reset()
+			viper.Set("endpoint", serverURL)
+			if tt.authToken != "" {
+				viper.Set("auth_token", tt.authToken)
+			}
+
+			streamsProjectID = tt.projectIDValue
+			streamsOutputFormat = "table"
+
+			err := streamsListCmd.RunE(streamsListCmd, []string{})
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestStreamsViperProjectIDFallback(t *testing.T) {
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results": []}`))
+		}),
+	)
+	defer server.Close()
+
+	viper.Reset()
+	viper.Set("endpoint", server.URL)
+	viper.Set("auth_token", "test-token")
+	viper.Set("project_id", 123)
+
+	streamsProjectID = 0
+	streamsOutputFormat = "table"
+
+	err := streamsListCmd.RunE(streamsListCmd, []string{})
+	assert.NoError(t, err)
+}
+
+func TestStreamsOutputFormat(t *testing.T) {
+	mockResponse := `{
+		"results": [{"id": "abc123", "name": "Rails Logs", "slug": "rails-logs", "internal": true, "project_id": null, "created_at": "2024-01-01T00:00:00Z"}]
+	}`
+
+	server := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(mockResponse))
+		}),
+	)
+	defer server.Close()
+
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{name: "table format", format: "table"},
+		{name: "json format", format: "json"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			viper.Reset()
+			viper.Set("endpoint", server.URL)
+			viper.Set("auth_token", "test-token")
+
+			streamsProjectID = 123
+			streamsOutputFormat = tt.format
+
+			err := streamsListCmd.RunE(streamsListCmd, []string{})
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/honeybadger-io/cli
 go 1.23
 
 require (
-	github.com/honeybadger-io/api-go v0.5.0
+	github.com/honeybadger-io/api-go v0.8.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlnd
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/honeybadger-io/api-go v0.5.0 h1:rLvofEgM6heH8T/g20i6EW9ymnYN2uEKgJfN6kSg9bE=
-github.com/honeybadger-io/api-go v0.5.0/go.mod h1:VurinfWN9qR1Bd9Zju2pIDgG1vIi5Qq3GpcsfToQiBU=
+github.com/honeybadger-io/api-go v0.8.0 h1:Od00qlzURBY1nTelJcBid9pg2lXC34iz2FMUs6lbj18=
+github.com/honeybadger-io/api-go v0.8.0/go.mod h1:VurinfWN9qR1Bd9Zju2pIDgG1vIi5Qq3GpcsfToQiBU=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
Bump api-go v0.5.0 to v0.8.0 and expose the new surface: streams list, faults update (resolve/ignore/assign/ resolve-on-deploy), insights query --stream-ids, and optional --account-id on projects create.