### PR TITLE
Update changelog for 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-17
+
 ### Added
 
 - Add `streams` command for listing Insights streams


### PR DESCRIPTION
Prep for v0.9.0 release: move Unreleased entries to 0.9.0 section.